### PR TITLE
fix: add /title command support

### DIFF
--- a/src/lib/modules/commands.ts
+++ b/src/lib/modules/commands.ts
@@ -36,41 +36,6 @@ export const server = function (serv: Server, { version }: Options) {
   }
 
   serv.commands.add({
-    base: 'title',
-    info: 'show title',
-    op: true,
-    usage: '/title <targets> (title|subtitle|actionBar) <title>',
-    parse (str) {
-      const match = str.match(/([A-Za-z0-9]+( [A-Za-z0-9]+)+) ^(title|subtitle|actionBar)$ \{[^}]*\}/i)
-      if (!match) return false
-      const players = str.split(/^(title|subtitle|actionBar)$/)[0]
-      const level = str.match(/^(title|subtitle|actionBar)$/)
-      const text = str.split(/^(title|subtitle|actionBar)$/)[-1]
-      if (!players || !level || !text) return false
-      return { playersNamesAndTargetValues: players, level: level[0], text: text }
-    },
-    action (data, ctx) {
-      const selectorString = ctx.player ? ctx.player.selectorString : serv.selectorString
-      const isPlayer = (entity: Entity): entity is Player => entity.type === 'player'
-      const players = selectorString(data.playersNamesAndTargetValues).filter(isPlayer)
-      switch (data.level) {
-        case 'title':
-          serv._writeArray("Title", { "set_title_text": data.text }, players)
-          break
-        case 'subtitle':
-          serv._writeArray("Title", { "set_title_subtitle": data.text }, players)
-          break
-        case 'actionBar':
-          serv._writeArray("Title", { "action_bar": data.text }, players)
-          break
-        default:
-          return "Something went wrong. Try again."
-      }
-      return "Title or action bar should appear"
-    }
-  })
-
-  serv.commands.add({
     base: 'ping',
     info: 'to pong!',
     usage: '/ping [number]',

--- a/src/lib/modules/players.ts
+++ b/src/lib/modules/players.ts
@@ -242,9 +242,14 @@ export const server = function (serv: Server, { version }: Options) {
       if (players.length < 1) throw new UserError('Player not found')
 
       const action = mode.toLowerCase()
-      if (action === 'clear' || action === 'reset') {
+      if (action === 'clear') {
         players.forEach(player => serv.clearTitle(player))
         return 'Title cleared'
+      }
+
+      if (action === 'reset') {
+        players.forEach(player => serv.resetTitle(player))
+        return 'Title reset'
       }
 
       if (action === 'times') {
@@ -266,7 +271,7 @@ export const server = function (serv: Server, { version }: Options) {
         players.forEach(player => serv.sendTitle(player, '', rest))
         return 'Subtitle sent'
       }
-      if (action === 'actionbar' || action === 'actionBar') {
+      if (action === 'actionbar') {
         players.forEach(player => serv.sendActionBar(player, rest))
         return 'Action bar sent'
       }

--- a/src/lib/modules/title.ts
+++ b/src/lib/modules/title.ts
@@ -22,19 +22,21 @@ export const server = function (serv: Server, options: Options) {
         fadeOut
       })
     } else {
-      // Pre-1.17 uses single title packet
+      player._client.write('title', {
+        action: 3,
+        fadeIn,
+        stay,
+        fadeOut
+      })
       if (title) {
         player._client.write('title', {
-          action: 0, // Set title
-          text: JSON.stringify({ text: title }),
-          fadeIn,
-          stay,
-          fadeOut
+          action: 0,
+          text: JSON.stringify({ text: title })
         })
       }
       if (subtitle) {
         player._client.write('title', {
-          action: 1, // Set subtitle
+          action: 1,
           text: JSON.stringify({ text: subtitle })
         })
       }
@@ -50,7 +52,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 2, // Set times
+        action: 3,
         fadeIn,
         stay,
         fadeOut
@@ -76,11 +78,23 @@ export const server = function (serv: Server, options: Options) {
   serv.clearTitle = (player: Player) => {
     if (supportsNewTitle) {
       player._client.write('clear_titles', {
+        reset: false
+      })
+    } else {
+      player._client.write('title', {
+        action: 4
+      })
+    }
+  }
+
+  serv.resetTitle = (player: Player) => {
+    if (supportsNewTitle) {
+      player._client.write('clear_titles', {
         reset: true
       })
     } else {
       player._client.write('title', {
-        action: 4 // Clear
+        action: 5
       })
     }
   }
@@ -92,5 +106,6 @@ declare global {
     setTitleTimes: (player: Player, fadeIn?: number, stay?: number, fadeOut?: number) => void
     sendActionBar: (player: Player, message: string) => void
     clearTitle: (player: Player) => void
+    resetTitle: (player: Player) => void
   }
 }


### PR DESCRIPTION
Fixes #5

## Changes

- **commands.ts**: Remove broken duplicate `/title` implementation (broken regex, wrong packet calls)
- **title.ts**: Fix pre-1.17 action codes - send times packet (action 3) separately before title/subtitle, fix `clearTitle` to use `reset: false`, add `resetTitle` with action 5
- **players.ts**: Differentiate `clear` vs `reset` actions, fix `actionbar` case normalisation

## IssueHunt

Resolves bounty: https://oss.issuehunt.io/r/zardoy/space-squid/issues/5