### PR TITLE
Implement vanilla-compatible /title command components

### DIFF
--- a/src/lib/modules/players.test.ts
+++ b/src/lib/modules/players.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import UserError from '../user_error'
+import { parseTitleMessage, parseTitleTimes } from './players'
+
+test('parseTitleMessage accepts vanilla JSON text components', () => {
+  expect(parseTitleMessage('{"text":"Hello","color":"gold"}')).toEqual({
+    text: 'Hello',
+    color: 'gold'
+  })
+})
+
+test('parseTitleMessage preserves plain text messages', () => {
+  expect(parseTitleMessage('Hello world')).toEqual('Hello world')
+})
+
+test('parseTitleMessage rejects invalid JSON components', () => {
+  expect(() => parseTitleMessage('{"text":')).toThrow(UserError)
+})
+
+test('parseTitleTimes validates three non-negative numbers', () => {
+  expect(parseTitleTimes('10 70 20')).toEqual({
+    fadeIn: 10,
+    stay: 70,
+    fadeOut: 20
+  })
+  expect(() => parseTitleTimes('10 70')).toThrow(UserError)
+  expect(() => parseTitleTimes('-1 70 20')).toThrow(UserError)
+  expect(() => parseTitleTimes('1x 70 20')).toThrow(UserError)
+})

--- a/src/lib/modules/players.ts
+++ b/src/lib/modules/players.ts
@@ -2,6 +2,30 @@ import UserError from '../user_error'
 import { skipMcPrefix } from '../utils'
 import PrismarineItem from 'prismarine-item'
 
+export const parseTitleMessage = (message: string) => {
+  const trimmed = message.trim()
+  if (!trimmed) throw new UserError('Title text is required')
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return message
+
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    throw new UserError('Title text must be valid JSON')
+  }
+}
+
+export const parseTitleTimes = (value: string) => {
+  const parts = value.trim().split(/\s+/)
+  if (parts.length !== 3) throw new UserError('Expected fadeIn, stay, and fadeOut')
+  if (parts.some(part => !/^\d+$/.test(part))) throw new UserError('Times must be numbers')
+  const times = parts.map(part => parseInt(part, 10))
+  return {
+    fadeIn: times[0],
+    stay: times[1],
+    fadeOut: times[2]
+  }
+}
+
 export const server = function (serv: Server, { version }: Options) {
   const mcData = serv.mcData
   const Item = PrismarineItem(version)
@@ -228,7 +252,7 @@ export const server = function (serv: Server, { version }: Options) {
   serv.commands.add({
     base: 'title',
     info: 'Show a title, subtitle, or action bar.',
-    usage: '/title <targets> (title|subtitle|actionbar|times|clear|reset) <message>',
+    usage: '/title <targets> (title|subtitle|actionbar|times|clear|reset) <message|times>',
     tab: ['selector', 'text'],
     op: true,
     parse (str) {
@@ -237,7 +261,6 @@ export const server = function (serv: Server, { version }: Options) {
       return { target: match[1], mode: match[2], rest: match[3] ?? '' }
     },
     action ({ target, mode, rest }, ctx) {
-      if (!ctx.player) return
       const players = serv.getPlayers(target, ctx.player)
       if (players.length < 1) throw new UserError('Player not found')
 
@@ -253,30 +276,28 @@ export const server = function (serv: Server, { version }: Options) {
       }
 
       if (action === 'times') {
-        const [fadeInRaw, stayRaw, fadeOutRaw] = rest.split(/\s+/)
-        const fadeIn = parseInt(fadeInRaw, 10)
-        const stay = parseInt(stayRaw, 10)
-        const fadeOut = parseInt(fadeOutRaw, 10)
-        if ([fadeIn, stay, fadeOut].some(Number.isNaN)) throw new UserError('Times must be numbers')
+        const { fadeIn, stay, fadeOut } = parseTitleTimes(rest)
         players.forEach(player => serv.setTitleTimes(player, fadeIn, stay, fadeOut))
         return 'Title times updated'
       }
 
-      if (!rest) throw new UserError('Title text is required')
+      if (!['title', 'subtitle', 'actionbar'].includes(action)) {
+        throw new UserError('Unknown title mode')
+      }
+
+      const message = parseTitleMessage(rest)
       if (action === 'title') {
-        players.forEach(player => serv.sendTitle(player, rest))
+        players.forEach(player => serv.sendTitle(player, message))
         return 'Title sent'
       }
       if (action === 'subtitle') {
-        players.forEach(player => serv.sendTitle(player, '', rest))
+        players.forEach(player => serv.sendTitle(player, '', message))
         return 'Subtitle sent'
       }
       if (action === 'actionbar') {
-        players.forEach(player => serv.sendActionBar(player, rest))
+        players.forEach(player => serv.sendActionBar(player, message))
         return 'Action bar sent'
       }
-
-      throw new UserError('Unknown title mode')
     }
   })
 }

--- a/src/lib/modules/title.test.ts
+++ b/src/lib/modules/title.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest'
+import { server as titleModule } from './title'
+
+const createHarness = (version: string) => {
+  const writes: Array<{ name: string, params: any }> = []
+  const serv = {
+    _createNetworkEncodedChatComponent: (value) => JSON.stringify(typeof value === 'string' ? { text: value } : value)
+  } as any
+  const player = {
+    _client: {
+      write: (name, params) => writes.push({ name, params })
+    }
+  } as any
+
+  titleModule(serv, { version } as any)
+  return { serv, player, writes }
+}
+
+test('sendTitle writes JSON components using the 1.17+ title packets', () => {
+  const { serv, player, writes } = createHarness('1.20.4')
+
+  serv.sendTitle(player, { text: 'Hello', color: 'gold' })
+
+  expect(writes).toEqual([
+    {
+      name: 'set_title_text',
+      params: { text: '{"text":"Hello","color":"gold"}' }
+    },
+    {
+      name: 'set_title_time',
+      params: { fadeIn: 10, stay: 70, fadeOut: 20 }
+    }
+  ])
+})
+
+test('sendActionBar writes JSON components using legacy title packets', () => {
+  const { serv, player, writes } = createHarness('1.16.5')
+
+  serv.sendActionBar(player, { text: 'Ready', color: 'green' })
+
+  expect(writes).toEqual([
+    {
+      name: 'title',
+      params: {
+        action: 2,
+        text: '{"text":"Ready","color":"green"}'
+      }
+    }
+  ])
+})

--- a/src/lib/modules/title.ts
+++ b/src/lib/modules/title.ts
@@ -2,18 +2,19 @@ import { versionToNumber } from '../../utils'
 
 export const server = function (serv: Server, options: Options) {
   const supportsNewTitle = versionToNumber(options.version) >= versionToNumber('1.17')
+  const titleText = (text: any) => serv._createNetworkEncodedChatComponent?.(text) ?? JSON.stringify(typeof text === 'string' ? { text } : text)
 
-  serv.sendTitle = (player: Player, title: string, subtitle?: string, fadeIn = 10, stay = 70, fadeOut = 20) => {
+  serv.sendTitle = (player: Player, title: any, subtitle?: any, fadeIn = 10, stay = 70, fadeOut = 20) => {
     if (supportsNewTitle) {
       // 1.17+ uses separate packets
       if (title) {
         player._client.write('set_title_text', {
-          text: JSON.stringify({ text: title })
+          text: titleText(title)
         })
       }
       if (subtitle) {
         player._client.write('set_title_subtitle', {
-          text: JSON.stringify({ text: subtitle })
+          text: titleText(subtitle)
         })
       }
       player._client.write('set_title_time', {
@@ -31,13 +32,13 @@ export const server = function (serv: Server, options: Options) {
       if (title) {
         player._client.write('title', {
           action: 0,
-          text: JSON.stringify({ text: title })
+          text: titleText(title)
         })
       }
       if (subtitle) {
         player._client.write('title', {
           action: 1,
-          text: JSON.stringify({ text: subtitle })
+          text: titleText(subtitle)
         })
       }
     }
@@ -60,17 +61,17 @@ export const server = function (serv: Server, options: Options) {
     }
   }
 
-  serv.sendActionBar = (player: Player, message: string) => {
+  serv.sendActionBar = (player: Player, message: any) => {
     if (supportsNewTitle) {
       // 1.17+ has dedicated action bar packet
       player._client.write('action_bar', {
-        text: JSON.stringify({ text: message })
+        text: titleText(message)
       })
     } else {
       // Pre-1.17 uses title packet with action 2
       player._client.write('title', {
         action: 2, // Action bar
-        text: JSON.stringify({ text: message })
+        text: titleText(message)
       })
     }
   }
@@ -102,9 +103,9 @@ export const server = function (serv: Server, options: Options) {
 
 declare global {
   interface Server {
-    sendTitle: (player: Player, title: string, subtitle?: string, fadeIn?: number, stay?: number, fadeOut?: number) => void
+    sendTitle: (player: Player, title: any, subtitle?: any, fadeIn?: number, stay?: number, fadeOut?: number) => void
     setTitleTimes: (player: Player, fadeIn?: number, stay?: number, fadeOut?: number) => void
-    sendActionBar: (player: Player, message: string) => void
+    sendActionBar: (player: Player, message: any) => void
     clearTitle: (player: Player) => void
     resetTitle: (player: Player) => void
   }


### PR DESCRIPTION
## Summary
- parse /title JSON text components while preserving plain text messages
- encode title/subtitle/actionbar through chat component serialization for old and new title packet formats
- allow /title to be executed from console contexts
- add parser and packet tests for the supported title behavior

Fixes #5.

## Verification
- pnpm build
- pnpm vitest run src/lib/modules/players.test.ts src/lib/modules/title.test.ts

Note: pnpm lint is currently not runnable because the repo script calls eslint, but eslint is not installed/declared in this checkout. The full vitest suite also has pre-existing legacy JS failures requiring the old package name flying-squid.