### PR TITLE
Fix title command timing preservation

### DIFF
--- a/src/lib/modules/players.ts
+++ b/src/lib/modules/players.ts
@@ -266,11 +266,13 @@ export const server = function (serv: Server, { version }: Options) {
 
       const action = mode.toLowerCase()
       if (action === 'clear') {
+        if (rest.trim()) throw new UserError('Clear does not accept extra arguments')
         players.forEach(player => serv.clearTitle(player))
         return 'Title cleared'
       }
 
       if (action === 'reset') {
+        if (rest.trim()) throw new UserError('Reset does not accept extra arguments')
         players.forEach(player => serv.resetTitle(player))
         return 'Title reset'
       }
@@ -287,11 +289,11 @@ export const server = function (serv: Server, { version }: Options) {
 
       const message = parseTitleMessage(rest)
       if (action === 'title') {
-        players.forEach(player => serv.sendTitle(player, message))
+        players.forEach(player => serv.sendTitleText(player, message))
         return 'Title sent'
       }
       if (action === 'subtitle') {
-        players.forEach(player => serv.sendTitle(player, '', message))
+        players.forEach(player => serv.sendSubtitle(player, message))
         return 'Subtitle sent'
       }
       if (action === 'actionbar') {

--- a/src/lib/modules/title.test.ts
+++ b/src/lib/modules/title.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { server as titleModule } from './title'
+import { server as playersModule } from './players'
 
 const createHarness = (version: string) => {
   const writes: Array<{ name: string, params: any }> = []
@@ -47,4 +48,71 @@ test('sendActionBar writes JSON components using legacy title packets', () => {
       }
     }
   ])
+})
+
+test('sendTitleText writes text without resetting title times', () => {
+  const { serv, player, writes } = createHarness('1.20.4')
+
+  serv.sendTitleText(player, { text: 'Hello', color: 'gold' })
+
+  expect(writes).toEqual([
+    {
+      name: 'set_title_text',
+      params: { text: '{"text":"Hello","color":"gold"}' }
+    }
+  ])
+})
+
+test('title command preserves timings when sending title text', () => {
+  const writes: Array<{ name: string, params: any }> = []
+  const commands: Record<string, any> = {}
+  const player = {
+    type: 'player',
+    _client: {
+      write: (name, params) => writes.push({ name, params })
+    }
+  } as any
+  const serv = {
+    mcData: {},
+    commands: {
+      add: command => { commands[command.base] = command }
+    },
+    selectorString: () => [player],
+    _createNetworkEncodedChatComponent: (value) => JSON.stringify(typeof value === 'string' ? { text: value } : value)
+  } as any
+
+  titleModule(serv, { version: '1.20.4' } as any)
+  playersModule(serv, { version: '1.20.4' } as any)
+
+  const titleCommand = commands.title
+  titleCommand.action(titleCommand.parse('@a times 1 2 3'), {})
+  titleCommand.action(titleCommand.parse('@a title {"text":"Hello"}'), {})
+
+  expect(writes).toEqual([
+    {
+      name: 'set_title_time',
+      params: { fadeIn: 1, stay: 2, fadeOut: 3 }
+    },
+    {
+      name: 'set_title_text',
+      params: { text: '{"text":"Hello"}' }
+    }
+  ])
+})
+
+test('title command rejects extra arguments for clear and reset', () => {
+  const commands: Record<string, any> = {}
+  const serv = {
+    mcData: {},
+    commands: {
+      add: command => { commands[command.base] = command }
+    },
+    selectorString: () => [{ type: 'player', _client: { write: () => {} } }]
+  } as any
+
+  titleModule(serv, { version: '1.20.4' } as any)
+  playersModule(serv, { version: '1.20.4' } as any)
+
+  expect(() => commands.title.action(commands.title.parse('@a clear extra'), {})).toThrow('Clear does not accept extra arguments')
+  expect(() => commands.title.action(commands.title.parse('@a reset extra'), {})).toThrow('Reset does not accept extra arguments')
 })

--- a/src/lib/modules/title.ts
+++ b/src/lib/modules/title.ts
@@ -8,14 +8,10 @@ export const server = function (serv: Server, options: Options) {
     if (supportsNewTitle) {
       // 1.17+ uses separate packets
       if (title) {
-        player._client.write('set_title_text', {
-          text: titleText(title)
-        })
+        serv.sendTitleText(player, title)
       }
       if (subtitle) {
-        player._client.write('set_title_subtitle', {
-          text: titleText(subtitle)
-        })
+        serv.sendSubtitle(player, subtitle)
       }
       player._client.write('set_title_time', {
         fadeIn,
@@ -30,17 +26,37 @@ export const server = function (serv: Server, options: Options) {
         fadeOut
       })
       if (title) {
-        player._client.write('title', {
-          action: 0,
-          text: titleText(title)
-        })
+        serv.sendTitleText(player, title)
       }
       if (subtitle) {
-        player._client.write('title', {
-          action: 1,
-          text: titleText(subtitle)
-        })
+        serv.sendSubtitle(player, subtitle)
       }
+    }
+  }
+
+  serv.sendTitleText = (player: Player, title: any) => {
+    if (supportsNewTitle) {
+      player._client.write('set_title_text', {
+        text: titleText(title)
+      })
+    } else {
+      player._client.write('title', {
+        action: 0,
+        text: titleText(title)
+      })
+    }
+  }
+
+  serv.sendSubtitle = (player: Player, subtitle: any) => {
+    if (supportsNewTitle) {
+      player._client.write('set_title_subtitle', {
+        text: titleText(subtitle)
+      })
+    } else {
+      player._client.write('title', {
+        action: 1,
+        text: titleText(subtitle)
+      })
     }
   }
 
@@ -104,6 +120,8 @@ export const server = function (serv: Server, options: Options) {
 declare global {
   interface Server {
     sendTitle: (player: Player, title: any, subtitle?: any, fadeIn?: number, stay?: number, fadeOut?: number) => void
+    sendTitleText: (player: Player, title: any) => void
+    sendSubtitle: (player: Player, subtitle: any) => void
     setTitleTimes: (player: Player, fadeIn?: number, stay?: number, fadeOut?: number) => void
     sendActionBar: (player: Player, message: any) => void
     clearTitle: (player: Player) => void


### PR DESCRIPTION
 #5.

## Summary
- add title/subtitle packet helpers that do not reset timings
- route `/title ... title` and `/title ... subtitle` through those helpers so prior `/title ... times` values are preserved
- reject extra arguments for `clear` and `reset`
- add regression coverage for the timing-preservation behavior

## Tests
- `pnpm vitest src/lib/modules/title.test.ts --run`
- `pnpm build`