### PR TITLE
Fix pre-1.11 title packet actions

### DIFF
--- a/src/lib/modules/title.test.ts
+++ b/src/lib/modules/title.test.ts
@@ -50,6 +50,73 @@ test('sendActionBar writes JSON components using legacy title packets', () => {
   ])
 })
 
+test('sendActionBar uses chat position for clients before title action bars', () => {
+  const { serv, player, writes } = createHarness('1.10')
+
+  serv.sendActionBar(player, { text: 'Ready', color: 'green' })
+
+  expect(writes).toEqual([
+    {
+      name: 'chat',
+      params: {
+        message: '{"text":"Ready","color":"green"}',
+        position: 2
+      }
+    }
+  ])
+})
+
+test('legacy title timing actions match 1.8-1.10 protocol layout', () => {
+  const { serv, player, writes } = createHarness('1.10')
+
+  serv.setTitleTimes(player, 1, 2, 3)
+  serv.clearTitle(player)
+  serv.resetTitle(player)
+
+  expect(writes).toEqual([
+    {
+      name: 'title',
+      params: { action: 2, fadeIn: 1, stay: 2, fadeOut: 3 }
+    },
+    {
+      name: 'title',
+      params: { action: 3 }
+    },
+    {
+      name: 'title',
+      params: { action: 4 }
+    }
+  ])
+})
+
+test('legacy title actions switch at 1.11 when actionbar was added', () => {
+  const { serv, player, writes } = createHarness('1.11')
+
+  serv.sendActionBar(player, { text: 'Ready' })
+  serv.setTitleTimes(player, 4, 5, 6)
+  serv.clearTitle(player)
+  serv.resetTitle(player)
+
+  expect(writes).toEqual([
+    {
+      name: 'title',
+      params: { action: 2, text: '{"text":"Ready"}' }
+    },
+    {
+      name: 'title',
+      params: { action: 3, fadeIn: 4, stay: 5, fadeOut: 6 }
+    },
+    {
+      name: 'title',
+      params: { action: 4 }
+    },
+    {
+      name: 'title',
+      params: { action: 5 }
+    }
+  ])
+})
+
 test('sendTitleText writes text without resetting title times', () => {
   const { serv, player, writes } = createHarness('1.20.4')
 

--- a/src/lib/modules/title.ts
+++ b/src/lib/modules/title.ts
@@ -2,6 +2,10 @@ import { versionToNumber } from '../../utils'
 
 export const server = function (serv: Server, options: Options) {
   const supportsNewTitle = versionToNumber(options.version) >= versionToNumber('1.17')
+  const supportsTitleActionBar = versionToNumber(options.version) >= versionToNumber('1.11')
+  const titleTimesAction = supportsTitleActionBar ? 3 : 2
+  const titleClearAction = supportsTitleActionBar ? 4 : 3
+  const titleResetAction = supportsTitleActionBar ? 5 : 4
   const titleText = (text: any) => serv._createNetworkEncodedChatComponent?.(text) ?? JSON.stringify(typeof text === 'string' ? { text } : text)
 
   serv.sendTitle = (player: Player, title: any, subtitle?: any, fadeIn = 10, stay = 70, fadeOut = 20) => {
@@ -20,7 +24,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 3,
+        action: titleTimesAction,
         fadeIn,
         stay,
         fadeOut
@@ -69,7 +73,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 3,
+        action: titleTimesAction,
         fadeIn,
         stay,
         fadeOut
@@ -84,11 +88,19 @@ export const server = function (serv: Server, options: Options) {
         text: titleText(message)
       })
     } else {
-      // Pre-1.17 uses title packet with action 2
-      player._client.write('title', {
-        action: 2, // Action bar
-        text: titleText(message)
-      })
+      if (supportsTitleActionBar) {
+        // 1.11-1.16 uses title packet action 2 for action bars.
+        player._client.write('title', {
+          action: 2,
+          text: titleText(message)
+        })
+      } else {
+        // 1.8-1.10 has no title action-bar action; use chat position 2.
+        player._client.write('chat', {
+          message: titleText(message),
+          position: 2
+        })
+      }
     }
   }
 
@@ -99,7 +111,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 4
+        action: titleClearAction
       })
     }
   }
@@ -111,7 +123,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 5
+        action: titleResetAction
       })
     }
   }


### PR DESCRIPTION
Fixes #5

## Summary
- use the pre-1.11 title packet action map for legacy timing, clear, and reset packets
- send action bars to 1.8-1.10 clients with chat position 2, since title action 2 is timing data there
- add focused 1.10 and 1.11 boundary tests so the old/new legacy split stays covered

## Tests
- `npx pnpm@10.5.2 vitest src/lib/modules/title.test.ts --run`
- `npx pnpm@10.5.2 build`
- `git diff --check`

IssueHunt: https://oss.issuehunt.io/r/zardoy/space-squid/issues/5