### PR TITLE
fix(title): restore pre-1.11 title packet behavior

### DIFF
--- a/src/lib/modules/title.test.ts
+++ b/src/lib/modules/title.test.ts
@@ -50,6 +50,23 @@ test('sendActionBar writes JSON components using legacy title packets', () => {
   ])
 })
 
+test('sendActionBar uses chat packets on pre-1.11 clients', () => {
+  const { serv, player, writes } = createHarness('1.10.2')
+
+  serv.sendActionBar(player, { text: 'Ready', color: 'green' })
+
+  expect(writes).toEqual([
+    {
+      name: 'chat',
+      params: {
+        message: '{"text":"Ready","color":"green"}',
+        position: 2,
+        sender: '0'
+      }
+    }
+  ])
+})
+
 test('sendTitleText writes text without resetting title times', () => {
   const { serv, player, writes } = createHarness('1.20.4')
 
@@ -115,4 +132,50 @@ test('title command rejects extra arguments for clear and reset', () => {
 
   expect(() => commands.title.action(commands.title.parse('@a clear extra'), {})).toThrow('Clear does not accept extra arguments')
   expect(() => commands.title.action(commands.title.parse('@a reset extra'), {})).toThrow('Reset does not accept extra arguments')
+})
+
+test('legacy title packets use pre-1.11 action ids for times, clear, and reset', () => {
+  const { serv, player, writes } = createHarness('1.10.2')
+
+  serv.setTitleTimes(player, 1, 2, 3)
+  serv.clearTitle(player)
+  serv.resetTitle(player)
+
+  expect(writes).toEqual([
+    {
+      name: 'title',
+      params: { action: 2, fadeIn: 1, stay: 2, fadeOut: 3 }
+    },
+    {
+      name: 'title',
+      params: { action: 3 }
+    },
+    {
+      name: 'title',
+      params: { action: 4 }
+    }
+  ])
+})
+
+test('legacy title packets switch action ids at 1.11', () => {
+  const { serv, player, writes } = createHarness('1.11')
+
+  serv.setTitleTimes(player, 1, 2, 3)
+  serv.clearTitle(player)
+  serv.resetTitle(player)
+
+  expect(writes).toEqual([
+    {
+      name: 'title',
+      params: { action: 3, fadeIn: 1, stay: 2, fadeOut: 3 }
+    },
+    {
+      name: 'title',
+      params: { action: 4 }
+    },
+    {
+      name: 'title',
+      params: { action: 5 }
+    }
+  ])
 })

--- a/src/lib/modules/title.ts
+++ b/src/lib/modules/title.ts
@@ -1,7 +1,12 @@
 import { versionToNumber } from '../../utils'
 
 export const server = function (serv: Server, options: Options) {
-  const supportsNewTitle = versionToNumber(options.version) >= versionToNumber('1.17')
+  const version = versionToNumber(options.version)
+  const supportsNewTitle = version >= versionToNumber('1.17')
+  const supportsLegacyTitleActionBar = version >= versionToNumber('1.11')
+  const legacyTitleActions = supportsLegacyTitleActionBar
+    ? { actionBar: 2, times: 3, clear: 4, reset: 5 }
+    : { actionBar: -1, times: 2, clear: 3, reset: 4 }
   const titleText = (text: any) => serv._createNetworkEncodedChatComponent?.(text) ?? JSON.stringify(typeof text === 'string' ? { text } : text)
 
   serv.sendTitle = (player: Player, title: any, subtitle?: any, fadeIn = 10, stay = 70, fadeOut = 20) => {
@@ -20,7 +25,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 3,
+        action: legacyTitleActions.times,
         fadeIn,
         stay,
         fadeOut
@@ -69,7 +74,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 3,
+        action: legacyTitleActions.times,
         fadeIn,
         stay,
         fadeOut
@@ -84,11 +89,18 @@ export const server = function (serv: Server, options: Options) {
         text: titleText(message)
       })
     } else {
-      // Pre-1.17 uses title packet with action 2
-      player._client.write('title', {
-        action: 2, // Action bar
-        text: titleText(message)
-      })
+      if (supportsLegacyTitleActionBar) {
+        player._client.write('title', {
+          action: legacyTitleActions.actionBar,
+          text: titleText(message)
+        })
+      } else {
+        player._client.write('chat', {
+          message: titleText(message),
+          position: 2,
+          sender: '0'
+        })
+      }
     }
   }
 
@@ -99,7 +111,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 4
+        action: legacyTitleActions.clear
       })
     }
   }
@@ -111,7 +123,7 @@ export const server = function (serv: Server, options: Options) {
       })
     } else {
       player._client.write('title', {
-        action: 5
+        action: legacyTitleActions.reset
       })
     }
   }


### PR DESCRIPTION
/claim #5

## Summary
- use the correct legacy title action IDs for 1.8-1.10 versus 1.11-1.16
- send action bars to 1.8-1.10 clients through the chat packet instead of legacy title action 2
- add boundary tests covering 1.10 and 1.11 behavior so the protocol split stays locked in

## Tests
- 
px pnpm@10.5.2 vitest src/lib/modules/title.test.ts --run
- 
px pnpm@10.5.2 build
- git diff --check

Refs #5